### PR TITLE
Init Sphinx Docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,42 @@
+name: "Sphinx: Render docs"
+
+on: 
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+    - name: Install dependencies
+      run: |
+        python3 -m pip install --upgrade pip
+        pip install .
+    - name: Build HTML
+      run: |
+        cd docs
+        make html
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: html-docs
+        path: docs/build/html/
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      if: github.ref == 'refs/heads/main'
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: docs/build/html

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,59 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Sphinx documentation
+docs/build/
+
+# Virtual environment
+venv/
+.venv/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,27 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'superneuroabm'
+copyright = '2024, Oak Ridge National Laboratories'
+author = 'Oak Ridge National Laboratories'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['sphinx.ext.autodoc']
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'classic'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. superneuroabm documentation master file, created by
+   sphinx-quickstart on Fri Dec  6 16:00:57 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to superneuroabm's documentation!
+=========================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   superneuroabm
+   superneuroabm.core
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+superneuroabm
+=============
+
+.. toctree::
+   :maxdepth: 4
+
+   superneuroabm

--- a/docs/source/superneuroabm.core.rst
+++ b/docs/source/superneuroabm.core.rst
@@ -1,0 +1,37 @@
+superneuroabm.core package
+==========================
+
+Submodules
+----------
+
+superneuroabm.core.agent module
+-------------------------------
+
+.. automodule:: superneuroabm.core.agent
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+superneuroabm.core.model module
+-------------------------------
+
+.. automodule:: superneuroabm.core.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+superneuroabm.core.util module
+------------------------------
+
+.. automodule:: superneuroabm.core.util
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: superneuroabm.core
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/superneuroabm.rst
+++ b/docs/source/superneuroabm.rst
@@ -1,0 +1,37 @@
+superneuroabm package
+=====================
+
+Subpackages
+-----------
+
+.. toctree::
+   :maxdepth: 4
+
+   superneuroabm.core
+
+Submodules
+----------
+
+superneuroabm.model module
+--------------------------
+
+.. automodule:: superneuroabm.model
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+superneuroabm.neuron module
+---------------------------
+
+.. automodule:: superneuroabm.neuron
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: superneuroabm
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
     long_description="""A GPU-based multi-agent simulation framework for neuromorphic computing.""",
     long_description_content_type="text/markdown",
     project_urls={"Source": "https://github.com/ORNL/superneuroabm"},
-    install_requires=["numba==0.55.1", "numpy==1.21.6", "tqdm==4.64.1"], 
+    install_requires=["numba==0.55.1", "numpy==1.21.6", "tqdm==4.64.1","sphinx"], 
 )


### PR DESCRIPTION
# Overview
This is an initial sphinx documentation that generates HTML webpages automatically upon any commit/pull request with main. The base of the docs was generated using `sphinx-quickstart` to create the general files. Additionally I used `sphinx-apidoc -o ./source ../superneuroabm` which helped generate the various `.rst` files. Using this you can run the following commands (which are in the `docs.yaml` workflow) to generate the docs.

`pip install .`
`cd docs`
`make html` 

These are very preliminary, but it generates the main files in `docs/build/html` that can be connected to github pages for deployment.

To see this deployed checkout my fork - https://joey-kilgore.github.io/superneuroabm/

## Specifics on changes
`.gitignore` - ignores the extra files from the docs, as well as standard python generated files that should be ignored (including a virtual environment)
`docs` - all of this is the generated files from sphinx
`setup.py` - add the additional dependencies needed for building docs/development (sphinx)

# **Notes for project admin**
To deploy this documentation the following steps need to be taken:
1. go to the project settings
2. go to the pages tab
3. select `deploy from branch` and choose branch `gh-pages` and the `/root` directory

Once this is merged and the action runs, it will take a few minutes but then will automatically deploy. 